### PR TITLE
Added support for sniffing packets in Wireshark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 
+#Private Files
+/wireshark
+/tests
+
 # Created by https://www.toptal.com/developers/gitignore/api/macos,linux,python
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,linux,python
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM osrf/ros:dashing-desktop
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV ROS_SECURITY_ROOT_DIRECTORY /security_keys
-ENV ROS_SECURITY_ENABLE true
+ENV ROS_SECURITY_ENABLE false
 ENV ROS_SECURITY_STRATEGY Enforce
 
 COPY launch root/launch

--- a/README.md
+++ b/README.md
@@ -2,4 +2,12 @@
 
 * Build image: `docker build -t demo .`
 * Run containers: `docker-compose up`. You should see the talker and listener communicating with each other.
+* Open Wireshark: `https://localhost:14500/?username=wireshark&password=wireshark`
 * Stop containers: `docker-compose down`
+
+<hr />
+
+### Note regarding Wireshark
+
+The URL opens in Firefox by clicking on `Accept Risk & Continue`.
+However, for Chromium-based browsers, you need to go to 'Allow invalid certificates for resources loaded from localhost.' in `chrome://flags`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,27 @@ services:
   talker:
     image: demo
     container_name: talker
+    networks:
+      - proxynet
     command: bash -c "/startup-vnc.sh & ros2 launch ./root/launch/talker_launch.py"
 
   listener:
     image: demo
     container_name: listener
+    networks:
+      - proxynet
     command: bash -c "/startup-vnc.sh & ros2 launch ./root/launch/listener_launch.py"
+
+  sniffer:
+    image: ffeldhaus/wireshark
+    container_name: wireshark
+    privileged: true
+    restart: unless-stopped
+    ports:
+      - "14500:14500"
+    networks:
+      - proxynet
+
+networks:
+  proxynet:
+    name: custom_network


### PR DESCRIPTION
I've turned the security settings off because I wanted to test the packets in Wireshark. I'll be sending another security-related PR where I'll turn it back on.